### PR TITLE
fix "proper" copyright notice

### DIFF
--- a/blue_book_electricity.py
+++ b/blue_book_electricity.py
@@ -1,4 +1,6 @@
-opyright (c) 2020 Poul-Henning Kamp <phk@phk.freebsd.dk>
+#!/usr/bin/env python
+#
+# Copyright (c) 2020 Poul-Henning Kamp <phk@phk.freebsd.dk>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
python was really unhappy about incorrect header in blue_book_electricity.py so here's fix allowing to run it hopefully out-of-box